### PR TITLE
Run nginx container as non-root user

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,6 @@ env:
 
 jobs:
   build-and-push-image:
-    if: ${{ github.ref == 'refs/heads/production' }}
     runs-on: ubuntu-latest
 
     permissions: write-all

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.6.0 as build
+FROM node:15.6.0 AS build
 
 ARG COMMIT_SHA
 ENV COMMIT_SHA=$COMMIT_SHA
@@ -15,12 +15,30 @@ FROM nginx:alpine
 
 RUN apk update && apk add curl git
 
+# Create a non-root user for nginx (use different GID to avoid conflicts)
+RUN addgroup -g 1001 -S appuser && \
+  adduser -S -D -H -u 1001 -h /var/cache/nginx -s /sbin/nologin -G appuser -g appuser appuser
+
+# Create necessary directories and set permissions
+RUN mkdir -p /var/cache/nginx /var/log/nginx /var/run /app && \
+  chown -R appuser:appuser /var/cache/nginx /var/log/nginx /var/run /app && \
+  # Give appuser access to nginx config directory
+  chown -R appuser:appuser /etc/nginx
+
 WORKDIR /app
 
 COPY --from=build /dist /app
-
 COPY ./config/up.html .
 COPY ./config/nginx.conf /etc/nginx/nginx.conf
 
+# Fix permissions for the app directory and nginx files
+RUN chown -R appuser:appuser /app /etc/nginx
+
+# Switch to non-root user
+USER appuser
+
+# Only expose port 3000 (remove port 80 since we don't need it with Traefik)
 EXPOSE 3000
-EXPOSE 80
+
+# Start nginx in foreground mode
+CMD ["nginx", "-g", "daemon off;"]

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -81,9 +81,9 @@ registry:
 #     accesslog.format: json
 
 # Configure a custom healthcheck (default is /up on port 3000)
-# healthcheck:
-#   path: /healthz
-#   port: 4000
+healthcheck:
+  path: /up
+  port: 3000
 
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid
 # hitting 404 on in-flight requests. Combines all files from new and old

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -1,3 +1,6 @@
+# PID file location (writable by non-root user)
+pid /tmp/nginx.pid;
+
 events {
     worker_connections 1024;
 }
@@ -9,9 +12,6 @@ http {
     server {
         listen 3000;
         listen [::]:3000;
-
-        listen 80;
-        listen [::]:80;
 
         resolver 127.0.0.1;
         autoindex off;


### PR DESCRIPTION
We don't want to use root user inside the containers so we'll instead
create a user and use that. This requires that we stop using port 80,
but Kamal should map the host port 80 to container port 3000.